### PR TITLE
Correct Snyk GitHub Action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
       
     - name: Run Snyk to check for vulnerabilities
-      uses: snyk/actions/python@master
+      uses: snyk/actions/golang@master
       with:
         command: monitor
         args: --project-name=conntest


### PR DESCRIPTION
Correct to use snyk/actions/golang@master as per https://github.com/snyk/actions/tree/master/golang.